### PR TITLE
Add calibration function to support measuring highest current resolution possible (0.1mA) at lowest range (16V, 400mA).

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -260,6 +260,90 @@ void Adafruit_INA219::ina219SetCalibration_32V_1A(void)
   wireWriteRegister(INA219_REG_CONFIG, config);
 }
 
+void Adafruit_INA219::ina219SetCalibration_16V_400mA(void) {
+  
+  // Calibration which uses the highest precision for 
+  // current measurement (0.1mA), at the expense of 
+  // only supporting 16V at 400mA max.
+
+  // VBUS_MAX = 16V
+  // VSHUNT_MAX = 0.04          (Assumes Gain 1, 40mV)
+  // RSHUNT = 0.1               (Resistor value in ohms)
+  
+  // 1. Determine max possible current
+  // MaxPossible_I = VSHUNT_MAX / RSHUNT
+  // MaxPossible_I = 0.4A
+
+  // 2. Determine max expected current
+  // MaxExpected_I = 0.4A
+  
+  // 3. Calculate possible range of LSBs (Min = 15-bit, Max = 12-bit)
+  // MinimumLSB = MaxExpected_I/32767
+  // MinimumLSB = 0.0000122              (12uA per bit)
+  // MaximumLSB = MaxExpected_I/4096
+  // MaximumLSB = 0.0000977              (98uA per bit)
+  
+  // 4. Choose an LSB between the min and max values
+  //    (Preferrably a roundish number close to MinLSB)
+  // CurrentLSB = 0.00005 (50uA per bit)
+  
+  // 5. Compute the calibration register
+  // Cal = trunc (0.04096 / (Current_LSB * RSHUNT))
+  // Cal = 8192 (0x2000)
+
+  ina219_calValue = 8192;
+
+  // 6. Calculate the power LSB
+  // PowerLSB = 20 * CurrentLSB
+  // PowerLSB = 0.001 (1mW per bit)
+  
+  // 7. Compute the maximum current and shunt voltage values before overflow
+  //
+  // Max_Current = Current_LSB * 32767
+  // Max_Current = 1.63835A before overflow
+  //
+  // If Max_Current > Max_Possible_I then
+  //    Max_Current_Before_Overflow = MaxPossible_I
+  // Else
+  //    Max_Current_Before_Overflow = Max_Current
+  // End If
+  //
+  // Max_Current_Before_Overflow = MaxPossible_I
+  // Max_Current_Before_Overflow = 0.4
+  //
+  // Max_ShuntVoltage = Max_Current_Before_Overflow * RSHUNT
+  // Max_ShuntVoltage = 0.04V
+  //
+  // If Max_ShuntVoltage >= VSHUNT_MAX
+  //    Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
+  // Else
+  //    Max_ShuntVoltage_Before_Overflow = Max_ShuntVoltage
+  // End If
+  //
+  // Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
+  // Max_ShuntVoltage_Before_Overflow = 0.04V
+  
+  // 8. Compute the Maximum Power
+  // MaximumPower = Max_Current_Before_Overflow * VBUS_MAX
+  // MaximumPower = 0.4 * 16V
+  // MaximumPower = 6.4W
+  
+  // Set multipliers to convert raw current/power values
+  ina219_currentDivider_mA = 20;  // Current LSB = 50uA per bit (1000/50 = 20)
+  ina219_powerDivider_mW = 1;     // Power LSB = 1mW per bit
+
+  // Set Calibration register to 'Cal' calculated above 
+  wireWriteRegister(INA219_REG_CALIBRATION, ina219_calValue);
+  
+  // Set Config register to take into account the settings above
+  uint16_t config = INA219_CONFIG_BVOLTAGERANGE_16V |
+                    INA219_CONFIG_GAIN_1_40MV |
+                    INA219_CONFIG_BADCRES_12BIT |
+                    INA219_CONFIG_SADCRES_12BIT_1S_532US |
+                    INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
+  wireWriteRegister(INA219_REG_CONFIG, config);
+}
+
 /**************************************************************************/
 /*! 
     @brief  Instantiates a new INA219 class

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -129,6 +129,7 @@ class Adafruit_INA219{
   void wireReadRegister(uint8_t reg, uint16_t *value);
   void ina219SetCalibration_32V_2A(void);
   void ina219SetCalibration_32V_1A(void);
+  void ina219SetCalibration_16V_400mA(void);
   int16_t getBusVoltage_raw(void);
   int16_t getShuntVoltage_raw(void);
   int16_t getCurrent_raw(void);


### PR DESCRIPTION
Here's a convenience function to configure the INA219 calibration to support measuring at 0.1mA resolution of current at 16V, 400mA max.  The function is not used by default because the range is much lower than the current default of 32V at 2A, instead it's provided as a convenience for anyone that doesn't want to calculate the values themselves.

Tested this by measuring the same load (an Arduino running a sketch consuming ~30mA up to ~140mA at specific points) and confirming this calibration had better current milliamp resolution.
