### PR TITLE
Wire on due

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -64,7 +64,11 @@ void Adafruit_INA219::wireReadRegister(uint8_t reg, uint16_t *value)
   #endif
   wire.endTransmission();
   
-  delay(1); // Max 12-bit conversion time is 586us per sample
+  #ifdef _CHIBIOS_RT_
+    chThdSleepMilliseconds(1);
+  #else
+    delay(1); // Max 12-bit conversion time is 586us per sample
+  #endif
 
   wire.requestFrom(ina219_i2caddr, (uint8_t)2);  
   #if ARDUINO >= 100

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -354,9 +354,14 @@ Adafruit_INA219::Adafruit_INA219(
   TwoWire& the_wire,
   delay_1msec_function the_delay
 )
-: wire(the_wire),
-  delay_1ms(the_delay)
+: wire(the_wire)
 {
+  delay_1ms=(
+    (!the_delay)? 
+      ([](void) { delay(1); }):
+      the_delay
+  );
+
   ina219_i2caddr = addr;
   ina219_currentDivider_mA = 0;
   ina219_powerDivider_mW = 0;

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -35,17 +35,17 @@
 /**************************************************************************/
 void Adafruit_INA219::wireWriteRegister (uint8_t reg, uint16_t value)
 {
-  Wire.beginTransmission(ina219_i2caddr);
+  wire.beginTransmission(ina219_i2caddr);
   #if ARDUINO >= 100
-    Wire.write(reg);                       // Register
-    Wire.write((value >> 8) & 0xFF);       // Upper 8-bits
-    Wire.write(value & 0xFF);              // Lower 8-bits
+    wire.write(reg);                       // Register
+    wire.write((value >> 8) & 0xFF);       // Upper 8-bits
+    wire.write(value & 0xFF);              // Lower 8-bits
   #else
-    Wire.send(reg);                        // Register
-    Wire.send(value >> 8);                 // Upper 8-bits
-    Wire.send(value & 0xFF);               // Lower 8-bits
+    wire.send(reg);                        // Register
+    wire.send(value >> 8);                 // Upper 8-bits
+    wire.send(value & 0xFF);               // Lower 8-bits
   #endif
-  Wire.endTransmission();
+  wire.endTransmission();
 }
 
 /**************************************************************************/
@@ -56,23 +56,23 @@ void Adafruit_INA219::wireWriteRegister (uint8_t reg, uint16_t value)
 void Adafruit_INA219::wireReadRegister(uint8_t reg, uint16_t *value)
 {
 
-  Wire.beginTransmission(ina219_i2caddr);
+  wire.beginTransmission(ina219_i2caddr);
   #if ARDUINO >= 100
-    Wire.write(reg);                       // Register
+    wire.write(reg);                       // Register
   #else
-    Wire.send(reg);                        // Register
+    wire.send(reg);                        // Register
   #endif
-  Wire.endTransmission();
+  wire.endTransmission();
   
   delay(1); // Max 12-bit conversion time is 586us per sample
 
-  Wire.requestFrom(ina219_i2caddr, (uint8_t)2);  
+  wire.requestFrom(ina219_i2caddr, (uint8_t)2);  
   #if ARDUINO >= 100
     // Shift values to create properly formed integer
-    *value = ((Wire.read() << 8) | Wire.read());
+    *value = ((wire.read() << 8) | wire.read());
   #else
     // Shift values to create properly formed integer
-    *value = ((Wire.receive() << 8) | Wire.receive());
+    *value = ((wire.receive() << 8) | wire.receive());
   #endif
 }
 
@@ -349,7 +349,9 @@ void Adafruit_INA219::setCalibration_16V_400mA(void) {
     @brief  Instantiates a new INA219 class
 */
 /**************************************************************************/
-Adafruit_INA219::Adafruit_INA219(uint8_t addr) {
+Adafruit_INA219::Adafruit_INA219(uint8_t addr, TwoWire& the_wire)
+: wire(the_wire)
+{
   ina219_i2caddr = addr;
   ina219_currentDivider_mA = 0;
   ina219_powerDivider_mW = 0;
@@ -366,7 +368,7 @@ void Adafruit_INA219::begin(uint8_t addr) {
 }
 
 void Adafruit_INA219::begin(void) {
-  Wire.begin();    
+  wire.begin();    
   // Set chip to large range config values to start
   setCalibration_32V_2A();
 }

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -63,12 +63,8 @@ void Adafruit_INA219::wireReadRegister(uint8_t reg, uint16_t *value)
     wire.send(reg);                        // Register
   #endif
   wire.endTransmission();
-  
-  #ifdef _CHIBIOS_RT_
-    chThdSleepMilliseconds(1);
-  #else
-    delay(1); // Max 12-bit conversion time is 586us per sample
-  #endif
+
+  delay_1ms(); // Max 12-bit conversion time is 586us per sample
 
   wire.requestFrom(ina219_i2caddr, (uint8_t)2);  
   #if ARDUINO >= 100
@@ -353,8 +349,13 @@ void Adafruit_INA219::setCalibration_16V_400mA(void) {
     @brief  Instantiates a new INA219 class
 */
 /**************************************************************************/
-Adafruit_INA219::Adafruit_INA219(uint8_t addr, TwoWire& the_wire)
-: wire(the_wire)
+Adafruit_INA219::Adafruit_INA219(
+  uint8_t addr, 
+  TwoWire& the_wire,
+  delay_1msec_function the_delay
+)
+: wire(the_wire),
+  delay_1ms(the_delay)
 {
   ina219_i2caddr = addr;
   ina219_currentDivider_mA = 0;

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -111,7 +111,7 @@
 
 class Adafruit_INA219{
  public:
-  Adafruit_INA219(uint8_t addr = INA219_ADDRESS);
+  Adafruit_INA219(uint8_t addr = INA219_ADDRESS,TwoWire& the_wire = Wire);
   void begin(void);
   void begin(uint8_t addr);
   void setCalibration_32V_2A(void);
@@ -124,6 +124,7 @@ class Adafruit_INA219{
  private:
   uint8_t ina219_i2caddr;
   uint32_t ina219_calValue;
+  TwoWire& wire;
   // The following multipliers are used to convert raw current and power
   // values to mA and mW, taking into account the current config settings
   uint32_t ina219_currentDivider_mA;

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -23,11 +23,6 @@
  #include "WProgram.h"
 #endif
 
-#ifdef _CHIBIOS_RT_
- #include "ChibiOS_ARM.h"
-#endif
-
-
 #include <Wire.h>
 
 /*=========================================================================
@@ -116,7 +111,14 @@
 
 class Adafruit_INA219{
  public:
-  Adafruit_INA219(uint8_t addr = INA219_ADDRESS,TwoWire& the_wire = Wire);
+
+  using delay_1msec_function=void (*)(void);
+
+  Adafruit_INA219(
+    uint8_t addr = INA219_ADDRESS,
+    TwoWire& the_wire = Wire,
+    delay_1msec_function the_delay=[](void) { delay(1); }
+  );
   void begin(void);
   void begin(uint8_t addr);
   void setCalibration_32V_2A(void);
@@ -130,6 +132,8 @@ class Adafruit_INA219{
   uint8_t ina219_i2caddr;
   uint32_t ina219_calValue;
   TwoWire& wire;
+  delay_1msec_function delay_1ms;
+
   // The following multipliers are used to convert raw current and power
   // values to mA and mW, taking into account the current config settings
   uint32_t ina219_currentDivider_mA;

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -119,8 +119,20 @@ class Adafruit_INA219{
     TwoWire& the_wire = Wire,
     delay_1msec_function the_delay=[](void) { delay(1); }
   );
+ 
   void begin(void);
   void begin(uint8_t addr);
+
+  bool set_delay_1msec_function(
+    delay_1msec_function the_delay=[](void) { delay(1); } 
+  ) 
+  {
+    if(!the_delay) return false;
+
+    delay_1ms=the_delay;
+    return true;
+  }
+
   void setCalibration_32V_2A(void);
   void setCalibration_32V_1A(void);
   void setCalibration_16V_400mA(void);

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -23,6 +23,11 @@
  #include "WProgram.h"
 #endif
 
+#ifdef _CHIBIOS_RT_
+ #include "ChibiOS_ARM.h"
+#endif
+
+
 #include <Wire.h>
 
 /*=========================================================================
@@ -131,7 +136,9 @@ class Adafruit_INA219{
   uint32_t ina219_powerDivider_mW;
   
   void wireWriteRegister(uint8_t reg, uint16_t value);
+  
   void wireReadRegister(uint8_t reg, uint16_t *value);
+
   int16_t getBusVoltage_raw(void);
   int16_t getShuntVoltage_raw(void);
   int16_t getCurrent_raw(void);

--- a/examples/getcurrent/getcurrent.pde
+++ b/examples/getcurrent/getcurrent.pde
@@ -1,7 +1,8 @@
 #include <Wire.h>
 #include <Adafruit_INA219.h>
 
-Adafruit_INA219 ina219;
+Adafruit_INA219 ina219; // using Wire  
+//Adafruit_INA219 ina219(0x40,Wire1); // using Wire1
 
 #if defined(ARDUINO_ARCH_SAMD)
 // for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!

--- a/examples/getcurrent/getcurrent.pde
+++ b/examples/getcurrent/getcurrent.pde
@@ -1,8 +1,38 @@
 #include <Wire.h>
 #include <Adafruit_INA219.h>
 
-Adafruit_INA219 ina219; // using Wire  
-//Adafruit_INA219 ina219(0x40,Wire1); // using Wire1
+//#define _CHIBIOS_RT_
+
+#ifdef _CHIBIOS_RT_
+ #include "ChibiOS_ARM.h"
+#endif
+
+#ifndef _CHIBIOS_RT_  
+
+//Adafruit_INA219 ina219; // using Wire  
+Adafruit_INA219 ina219(INA219_ADDRESS,Wire1); // using Wire1
+
+#else // using ChibiOS
+// using another 1 msec delay funtion
+// concretely the one used with ChibiOS
+// in project A-Tirma
+//Adafruit_INA219 ina219(
+//  INA219_ADDRESS, // INA219's I2C address
+//  Wire, // using the second I2C device on the DUE
+//  //using a specific ChibiOS function for the
+//  // 1 msec delay necessary using when reading
+//  // the INA219
+//  [](void) { chThdSleepMilliseconds(1); }
+//); // using Wire
+Adafruit_INA219 ina219(
+  INA219_ADDRESS, // INA219's I2C address
+  Wire1, // using the second I2C device on the DUE
+  //using a specific ChibiOS function for the
+  // 1 msec delay necessary using when reading
+  // the INA219
+  [](void) { chThdSleepMilliseconds(1); }
+); // using Wire1
+#endif
 
 #if defined(ARDUINO_ARCH_SAMD)
 // for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!

--- a/examples/getcurrent/getcurrent.pde
+++ b/examples/getcurrent/getcurrent.pde
@@ -20,7 +20,7 @@ Adafruit_INA219 ina219(INA219_ADDRESS,Wire1); // using Wire1
 //  INA219_ADDRESS, // INA219's I2C address
 //  Wire, // using the second I2C device on the DUE
 //  //using a specific ChibiOS function for the
-//  // 1 msec delay necessary using when reading
+//  // 1 msec delay necessary when reading
 //  // the INA219
 //  [](void) { chThdSleepMilliseconds(1); }
 //); // using Wire
@@ -28,7 +28,7 @@ Adafruit_INA219 ina219(
   INA219_ADDRESS, // INA219's I2C address
   Wire1, // using the second I2C device on the DUE
   //using a specific ChibiOS function for the
-  // 1 msec delay necessary using when reading
+  // 1 msec delay necessary when reading
   // the INA219
   [](void) { chThdSleepMilliseconds(1); }
 ); // using Wire1


### PR DESCRIPTION
I have modified the library in order to be able to use the second I2C interface available on the DUE, corresponding to Wire1 on the Arduino DUE. Now we can pass a TwoWire object at the constructor of Adafruit_INA219 class. By default the object the library uses is Wire. I have tested the changes and they works satisfactorily.
