### PR TITLE
Add methods to enable the control of the power mode

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -517,3 +517,32 @@ float Adafruit_INA219::getPower_mW() {
   valueDec *= ina219_powerMultiplier_mW;
   return valueDec;
 }
+
+/**************************************************************************/
+/*!
+    @brief  Sets the INA219 power operating mode. Default is continuous
+            sampling. To reduce power consumption, use
+            INA219_CONFIG_MODE_POWERDOWN which will save ~0.7mA
+*/
+/**************************************************************************/
+void Adafruit_INA219::setOperatingMode( Adafruit_INA219_OperatingMode mode ) {
+  uint16_t config;
+  wireReadRegister(INA219_REG_CONFIG, &config);
+  config &= 0xfff8;
+  config |= mode;
+  wireWriteRegister(INA219_REG_CONFIG, config);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Returns the current INA219 power operating mode
+    @return Current power operating mode
+*/
+/**************************************************************************/
+Adafruit_INA219_OperatingMode Adafruit_INA219::getOperatingMode() {
+  uint16_t config;
+  wireReadRegister(INA219_REG_CONFIG, &config);
+  config &= 0x07;
+  return (Adafruit_INA219_OperatingMode)config;
+}
+

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -151,7 +151,7 @@ enum {
     @brief  values for operating mode
 */
 /**************************************************************************/
- enum {
+typedef enum {
     INA219_CONFIG_MODE_POWERDOWN          =  (0x0000),
     INA219_CONFIG_MODE_SVOLT_TRIGGERED    =  (0x0001),
     INA219_CONFIG_MODE_BVOLT_TRIGGERED    =  (0x0002),
@@ -160,7 +160,7 @@ enum {
     INA219_CONFIG_MODE_SVOLT_CONTINUOUS  =  (0x0005),
     INA219_CONFIG_MODE_BVOLT_CONTINUOUS   =  (0x0006),
     INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS = (0x0007),
-};
+} Adafruit_INA219_Operating_Mode;
 /*=========================================================================*/
 
 /**************************************************************************/
@@ -220,6 +220,9 @@ class Adafruit_INA219{
   float getShuntVoltage_mV(void);
   float getCurrent_mA(void);
   float getPower_mW(void);
+
+  void setOperatingMode( Adafruit_INA219_OperatingMode mode );
+  Adafruit_INA219_OperatingMode getOperatingMode();
 
  private:
   TwoWire *_i2c;


### PR DESCRIPTION
Add get/set methods to configure the operating mode of the INA219 primarily such that the chip can be powered off. This saves around 0.7mA@3.3V.
