### PR TITLE
Remove unnecessary dependencies from `library.properties`.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=INA219 Current Sensor
 category=Sensors
 url=https://github.com/adafruit/Adafruit_INA219
 architectures=*
-depends=Adafruit NeoPixel, Adafruit GFX Library, Adafruit SSD1306
+


### PR DESCRIPTION
Unfortunately commit f6f7d9ffb6112d3fa15988dc131895b61fe5dfa5 included additional dependencies into the `library.properties` file which are not necessary for the INA219 sensor.

This PR removes them again.