### PR TITLE
Fix memory leak in Adafruit_INA_219::begin() in subsequent calls

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -41,6 +41,13 @@ Adafruit_INA219::Adafruit_INA219(uint8_t addr) {
 }
 
 /*!
+ *  @brief INA219 class destructor
+ */  
+Adafruit_INA219::~Adafruit_INA219() {
+  delete i2c_dev;
+}
+
+/*!
  *  @brief  Sets up the HW (defaults to 32V and 2A for calibration values)
  *  @param theWire the TwoWire object to use
  *  @return true: success false: Failed to start I2C

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -43,9 +43,7 @@ Adafruit_INA219::Adafruit_INA219(uint8_t addr) {
 /*!
  *  @brief INA219 class destructor
  */  
-Adafruit_INA219::~Adafruit_INA219() {
-  delete i2c_dev;
-}
+Adafruit_INA219::~Adafruit_INA219() { delete i2c_dev; }
 
 /*!
  *  @brief  Sets up the HW (defaults to 32V and 2A for calibration values)

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -46,7 +46,9 @@ Adafruit_INA219::Adafruit_INA219(uint8_t addr) {
  *  @return true: success false: Failed to start I2C
  */
 bool Adafruit_INA219::begin(TwoWire *theWire) {
-  i2c_dev = new Adafruit_I2CDevice(ina219_i2caddr, theWire);
+  if (!i2c_dev) {
+    i2c_dev = new Adafruit_I2CDevice(ina219_i2caddr, theWire);
+  }
 
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -42,7 +42,7 @@ Adafruit_INA219::Adafruit_INA219(uint8_t addr) {
 
 /*!
  *  @brief INA219 class destructor
- */  
+ */
 Adafruit_INA219::~Adafruit_INA219() { delete i2c_dev; }
 
 /*!

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -149,6 +149,7 @@ enum {
 class Adafruit_INA219 {
 public:
   Adafruit_INA219(uint8_t addr = INA219_ADDRESS);
+  ~Adafruit_INA219();
   bool begin(TwoWire *theWire = &Wire);
   void setCalibration_32V_2A();
   void setCalibration_32V_1A();


### PR DESCRIPTION
Scope:
Adds a null-pointer check on i2c_dev in begin() to avoid memory leak if begin() is called more than once, e.g. if begin() fails the first time.
Adds destructor to class.

Limitations:
Does not address memory issues with default shallow copy constructor.