### PR TITLE
Success!

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -476,6 +476,4 @@ void Adafruit_INA219::setCalibration_16V_400mA() {
  *          e.g. calibration before read/write, only the final operation's
  *          result is stored.
  */
-bool Adafruit_INA219::success() {
-  return _success;
-}
+bool Adafruit_INA219::success() { return _success; }

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -72,7 +72,7 @@ int16_t Adafruit_INA219::getBusVoltage_raw() {
 
   Adafruit_BusIO_Register bus_voltage_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_BUSVOLTAGE, 2, MSBFIRST);
-  bus_voltage_reg.read(&value);
+  _success = bus_voltage_reg.read(&value);
 
   // Shift to the right 3 to drop CNVR and OVF and multiply by LSB
   return (int16_t)((value >> 3) * 4);
@@ -86,7 +86,7 @@ int16_t Adafruit_INA219::getShuntVoltage_raw() {
   uint16_t value;
   Adafruit_BusIO_Register shunt_voltage_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_SHUNTVOLTAGE, 2, MSBFIRST);
-  shunt_voltage_reg.read(&value);
+  _success = shunt_voltage_reg.read(&value);
   return value;
 }
 
@@ -108,7 +108,7 @@ int16_t Adafruit_INA219::getCurrent_raw() {
   // Now we can safely read the CURRENT register!
   Adafruit_BusIO_Register current_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CURRENT, 2, MSBFIRST);
-  current_reg.read(&value);
+  _success = current_reg.read(&value);
   return value;
 }
 
@@ -130,7 +130,7 @@ int16_t Adafruit_INA219::getPower_raw() {
   // Now we can safely read the POWER register!
   Adafruit_BusIO_Register power_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_POWER, 2, MSBFIRST);
-  power_reg.read(&value);
+  _success = power_reg.read(&value);
   return value;
 }
 
@@ -262,7 +262,7 @@ void Adafruit_INA219::setCalibration_32V_2A() {
                     INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
-  config_reg.write(config, 2);
+  _success = config_reg.write(config, 2);
 }
 
 /*!
@@ -277,9 +277,9 @@ void Adafruit_INA219::powerSave(bool on) {
   Adafruit_BusIO_RegisterBits mode_bits =
       Adafruit_BusIO_RegisterBits(&config_reg, 3, 0);
   if (on) {
-    mode_bits.write(INA219_CONFIG_MODE_POWERDOWN);
+    _success = mode_bits.write(INA219_CONFIG_MODE_POWERDOWN);
   } else {
-    mode_bits.write(INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS);
+    _success = mode_bits.write(INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS);
   }
 }
 
@@ -373,7 +373,7 @@ void Adafruit_INA219::setCalibration_32V_1A() {
                     INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
-  config_reg.write(config, 2);
+  _success = config_reg.write(config, 2);
 }
 
 /*!
@@ -465,5 +465,17 @@ void Adafruit_INA219::setCalibration_16V_400mA() {
 
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
-  config_reg.write(config, 2);
+  _success = config_reg.write(config, 2);
+}
+
+/*!
+ *  @brief  Provides the the underlying return value from the last operation
+ *          called on the device.
+ *  @return true: Last operation was successful false: Last operation failed
+ *  @note   For function calls that have intermediary device operations,
+ *          e.g. calibration before read/write, only the final operation's
+ *          result is stored.
+ */
+bool Adafruit_INA219::success() {
+  return _success;
 }

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -158,9 +158,12 @@ public:
   float getCurrent_mA();
   float getPower_mW();
   void powerSave(bool on);
+  bool success();
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL;
+
+  bool _success;
 
   uint8_t ina219_i2caddr = -1;
   uint32_t ina219_calValue;


### PR DESCRIPTION
Scope:
Adds `bool Adafruit_INA219::success()` and associated private class `bool success`. This value is updated based on calls to parent class functions. It allows error checking on the i/o operation itself as opposed to relying on, for example, checking the value returned from any of the read functions. Implemented in this fashion in order to conform to Arduino style guidelines (avoiding use of pointers) while not breaking existing code based on this library.

Limitations:
Only provides feedback from the last i/o operation that occurs in the called functions. For example, calibration functions called will update `_success`, but calibration functions called as part of a read function will have this value overwritten by the final read operation.