### PR TITLE
Update getcurrent.ino

### DIFF
--- a/examples/getcurrent/getcurrent.ino
+++ b/examples/getcurrent/getcurrent.ino
@@ -43,7 +43,7 @@ void loop(void)
   busvoltage = ina219.getBusVoltage_V();
   current_mA = ina219.getCurrent_mA();
   power_mW = ina219.getPower_mW();
-  loadvoltage = busvoltage + (shuntvoltage / 1000);
+  loadvoltage = busvoltage - (shuntvoltage / 1000);
   
   Serial.print("Bus Voltage:   "); Serial.print(busvoltage); Serial.println(" V");
   Serial.print("Shunt Voltage: "); Serial.print(shuntvoltage); Serial.println(" mV");


### PR DESCRIPTION
The load voltage must be the bus voltage minus the shunt resistor voltage. In a series circuit some voltage drop will exist in the shunt resistor, and this voltage don`t go to the load, to compute the load voltage is necessary to subtract the shunt voltage from the bus Voltage. Just a sign change, but it`s make total difference in the values.

Thanks for attention!