### PR TITLE
Brief corrected for Adafruit_INA219::getBusVoltage_V

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -152,7 +152,7 @@ float Adafruit_INA219::getShuntVoltage_mV() {
 }
 
 /*!
- *  @brief  Gets the shunt voltage in volts
+ *  @brief  Gets the bus voltage in volts
  *  @return the bus voltage converted to volts
  */
 float Adafruit_INA219::getBusVoltage_V() {


### PR DESCRIPTION
Fixed incorrect @brief to match function ("bus" instead of "shunt").
- Only the documentation brief was modified
- Applies to all platforms (only documentation was modified)