### PR TITLE
Add a macro to calculate the I2C address based on the A0 and A1 pads

### DIFF
--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -22,6 +22,13 @@
 #include <Adafruit_I2CDevice.h>
 #include <Wire.h>
 
+/** I2C address calculations 0 == GND, 1 == V+ **/
+/* 0x1000ABCD
+ * A and B are controlled by A1: GND = 00, V+ = 01, SDA = 10, SCL = 11
+ * C and D are controlled by A0: GND = 00, V+ = 01, SDA = 10, SCL = 11
+ * SDA and SCL options aren't implemented. */
+#define INA219_CALC_ADDRESS(A0, A1) (0x40 | (A0 != 0 ? 0x01 : 0x00) | (A1 != 0 ? 0x04 : 0x00))
+
 /** default I2C address **/
 #define INA219_ADDRESS (0x40) // 1000000 (A0+A1=GND)
 

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -22,11 +22,18 @@
 #include <Adafruit_I2CDevice.h>
 #include <Wire.h>
 
-/** I2C address calculations 0 == GND, 1 == V+ **/
-/* 0x1000ABCD
- * A and B are controlled by A1: GND = 00, V+ = 01, SDA = 10, SCL = 11
- * C and D are controlled by A0: GND = 00, V+ = 01, SDA = 10, SCL = 11
- * SDA and SCL options aren't implemented. */
+/** calculated I2C address: 0 = GND, 1 = V+ **/
+/* The address is controlled by the A0 and A1 inputs on the INA219:
+ *
+ * Calculated address: b100ABCD
+ * A0 controls C and D: GND = 00, V+ = 01, SDA = 10, SCL = 11
+ * A1 controls A and B: GND = 00, V+ = 01, SDA = 10, SCL = 11
+ *
+ * E.g. if A0 is tied to ground and A1 is tied to V+,
+ * the resulting address is b1000100 = 0x44
+ *
+ * SDA and SCL options aren't implemented.
+ */
 #define INA219_CALC_ADDRESS(INA_ADDR0, INA_ADDR1)                              \
   (0x40 | (INA_ADDR0 != 0 ? 0x01 : 0x00) | (INA_ADDR1 != 0 ? 0x04 : 0x00))
 

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -27,7 +27,8 @@
  * A and B are controlled by A1: GND = 00, V+ = 01, SDA = 10, SCL = 11
  * C and D are controlled by A0: GND = 00, V+ = 01, SDA = 10, SCL = 11
  * SDA and SCL options aren't implemented. */
-#define INA219_CALC_ADDRESS(A0, A1) (0x40 | (A0 != 0 ? 0x01 : 0x00) | (A1 != 0 ? 0x04 : 0x00))
+#define INA219_CALC_ADDRESS(A0, A1)                                            \
+  (0x40 | (A0 != 0 ? 0x01 : 0x00) | (A1 != 0 ? 0x04 : 0x00))
 
 /** default I2C address **/
 #define INA219_ADDRESS (0x40) // 1000000 (A0+A1=GND)

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -27,8 +27,8 @@
  * A and B are controlled by A1: GND = 00, V+ = 01, SDA = 10, SCL = 11
  * C and D are controlled by A0: GND = 00, V+ = 01, SDA = 10, SCL = 11
  * SDA and SCL options aren't implemented. */
-#define INA219_CALC_ADDRESS(A0, A1)                                            \
-  (0x40 | (A0 != 0 ? 0x01 : 0x00) | (A1 != 0 ? 0x04 : 0x00))
+#define INA219_CALC_ADDRESS(INA_ADDR0, INA_ADDR1)                              \
+  (0x40 | (INA_ADDR0 != 0 ? 0x01 : 0x00) | (INA_ADDR1 != 0 ? 0x04 : 0x00))
 
 /** default I2C address **/
 #define INA219_ADDRESS (0x40) // 1000000 (A0+A1=GND)


### PR DESCRIPTION
This module and derivatives of it have pads broken out to set the A0 and A1 pins to either ground or V+, and while the way this adjusts the I2C address is explained in the documentation, the library doesn't document this or provide any way to calculate the address.

This adds a separate macro to perform the address calculations, and adds a brief explanation of how the address is calculated.

I've not modified the existing address #define as it's useful to have the exact number visible for IDEs who show that.

This has been tested by verifying that it produces the correct addresses according to the documentation, but not on actual hardware as my only INA219 board is in-use with a solder bridge on the A0 pads.