### PR TITLE
Add ADC resolution options

### DIFF
--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -297,7 +297,7 @@ void Adafruit_INA219::powerSave(bool on) {
  */
 void Adafruit_INA219::setBusADCResolution(uint16_t resolution) {
   // See the INA219_CONFIG_BADCRES enums for the various options
-  // The default set by setCalibration functions is NA219_CONFIG_BADCRES_12BIT 
+  // The default set by setCalibration functions is NA219_CONFIG_BADCRES_12BIT
   
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
@@ -316,7 +316,8 @@ void Adafruit_INA219::setBusADCResolution(uint16_t resolution) {
  */
 void Adafruit_INA219::setShuntADCResolution(uint16_t resolution) {
   // See the INA219_CONFIG_SADCRES enums for the various options
-  // The default set by setCalibration functions is INA219_CONFIG_SADCRES_12BIT_1S_532US 
+  // The default set by setCalibration functions is
+  // INA219_CONFIG_SADCRES_12BIT_1S_532US
   
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -302,9 +302,11 @@ void Adafruit_INA219::setBusADCResolution(uint16_t resolution) {
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
 
-  Adafruit_BusIO_RegisterBits mode_bits =
-      Adafruit_BusIO_RegisterBits(&config_reg, 4, 3);
-    _success = mode_bits.write(resolution);
+  uint32_t val = config_reg.read();
+  // Mask off area and set our new values
+  val &= ~INA219_CONFIG_BADCRES_MASK;
+  val |= resolution;
+  _success = config_reg.write(val, 2);
 }
 
 /*!
@@ -319,9 +321,11 @@ void Adafruit_INA219::setShuntADCResolution(uint16_t resolution) {
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
 
-  Adafruit_BusIO_RegisterBits mode_bits =
-      Adafruit_BusIO_RegisterBits(&config_reg, 4, 7);
-    _success = mode_bits.write(resolution);
+  uint32_t val = config_reg.read();
+  // Mask off area and set our new values
+  val &= ~INA219_CONFIG_SADCRES_MASK;
+  val |= resolution;
+  _success = config_reg.write(val, 2);
 }
 
 /*!

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -298,7 +298,7 @@ void Adafruit_INA219::powerSave(bool on) {
 void Adafruit_INA219::setBusADCResolution(uint16_t resolution) {
   // See the INA219_CONFIG_BADCRES enums for the various options
   // The default set by setCalibration functions is NA219_CONFIG_BADCRES_12BIT
-  
+
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
 
@@ -318,7 +318,7 @@ void Adafruit_INA219::setShuntADCResolution(uint16_t resolution) {
   // See the INA219_CONFIG_SADCRES enums for the various options
   // The default set by setCalibration functions is
   // INA219_CONFIG_SADCRES_12BIT_1S_532US
-  
+
   Adafruit_BusIO_Register config_reg =
       Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
 

--- a/Adafruit_INA219.cpp
+++ b/Adafruit_INA219.cpp
@@ -291,6 +291,40 @@ void Adafruit_INA219::powerSave(bool on) {
 }
 
 /*!
+ *  @brief  Set Bus ADC resolution and averaging options
+ *  @param  resolution
+ *          resolution option enum
+ */
+void Adafruit_INA219::setBusADCResolution(uint16_t resolution) {
+  // See the INA219_CONFIG_BADCRES enums for the various options
+  // The default set by setCalibration functions is NA219_CONFIG_BADCRES_12BIT 
+  
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
+
+  Adafruit_BusIO_RegisterBits mode_bits =
+      Adafruit_BusIO_RegisterBits(&config_reg, 4, 3);
+    _success = mode_bits.write(resolution);
+}
+
+/*!
+ *  @brief  Set Shunt ADC resolution and averaging options
+ *  @param  resolution
+ *          resolution option enum
+ */
+void Adafruit_INA219::setShuntADCResolution(uint16_t resolution) {
+  // See the INA219_CONFIG_SADCRES enums for the various options
+  // The default set by setCalibration functions is INA219_CONFIG_SADCRES_12BIT_1S_532US 
+  
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
+
+  Adafruit_BusIO_RegisterBits mode_bits =
+      Adafruit_BusIO_RegisterBits(&config_reg, 4, 7);
+    _success = mode_bits.write(resolution);
+}
+
+/*!
  *  @brief  Configures to INA219 to be able to measure up to 32V and 1A
  *          of current.  Each unit of current corresponds to 40uA, and each
  *          unit of power corresponds to 800uW. Counter overflow occurs at

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -174,6 +174,8 @@ public:
   float getCurrent_mA();
   float getPower_mW();
   void powerSave(bool on);
+  void setBusADCResolution(uint16_t resolution) 
+  void setShuntADCResolution(uint16_t resolution) 
   bool success();
 
 private:

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -174,8 +174,8 @@ public:
   float getCurrent_mA();
   float getPower_mW();
   void powerSave(bool on);
-  void setBusADCResolution(uint16_t resolution); 
-  void setShuntADCResolution(uint16_t resolution); 
+  void setBusADCResolution(uint16_t resolution);
+  void setShuntADCResolution(uint16_t resolution);
   bool success();
 
 private:

--- a/Adafruit_INA219.h
+++ b/Adafruit_INA219.h
@@ -174,8 +174,8 @@ public:
   float getCurrent_mA();
   float getPower_mW();
   void powerSave(bool on);
-  void setBusADCResolution(uint16_t resolution) 
-  void setShuntADCResolution(uint16_t resolution) 
+  void setBusADCResolution(uint16_t resolution); 
+  void setShuntADCResolution(uint16_t resolution); 
   bool success();
 
 private:


### PR DESCRIPTION
This PR is in response to the issue I raised here: #62 

It adds two new functions setShuntADCResolution and setBusADCResolution which use the already defined values for setting the ADC resolution and averaging options, such as INA219_CONFIG_SADCRES_12BIT_128S_69MS

It has been tested on an Adafruit ESP32-S3-TFT Feather connected to an Adafruit INA219 breakout board.

By running a test calling getCurrent_mA 1000 times over 350mS (the fastest speed available by setting the I2C bus speed to 400000) while reading the current of a motor, I was able to prove that the different settings worked. The INA219 chip always gives you the last reading, even if there isn't a new value ready yet.

For example, when running with the default option (INA219_CONFIG_SADCRES_12BIT_1S_532US), you can see every value was different (motors are noisy!). However, when the setting was changed to INA219_CONFIG_SADCRES_12BIT_128S_69MS, you can see it takes nearly 200 readings until the value changes. 350mS / 1000 samples = 0.35ms per reading. 0.35ms x 197 samples = 68.95ms. In addition, the values were obviously "averegaed".
